### PR TITLE
Explicit dependency on colors (fix #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "yeoman-generator": "https://github.com/yeoman/generator/archive/master.tar.gz"
+    "yeoman-generator": "https://github.com/yeoman/generator/archive/master.tar.gz",
+    "colors": "~0.6.0"
   },
   "devDependencies": {
     "mocha": "~1.8.1"


### PR DESCRIPTION
`colors` is an dependency as it is used to output colored messages (on error).
