### PR TITLE
Reporters not working as expected

### DIFF
--- a/app/templates/testacular.conf.js
+++ b/app/templates/testacular.conf.js
@@ -19,8 +19,8 @@ files = [
 exclude = [];
 
 // test results reporter to use
-// possible values: dots || progress
-reporter = 'progress';
+// possible values: dots || progress || growl
+reporters = ['progress'];
 
 // web server port
 port = 8080;


### PR DESCRIPTION
I'm not very familiar with all possible testacular config options, I was trying to make
the 'growl' reporter to work and figured out the config should have a `reporters` instead of `reporter` options and the value should be an array (according to [testacular docs](https://github.com/testacular/testacular/blob/master/test/client/testacular.conf.js#L30), at least)
