### PR TITLE
Angular scenarios in the test environment

### DIFF
--- a/app/templates/testacular-e2e.conf.js
+++ b/app/templates/testacular-e2e.conf.js
@@ -1,0 +1,18 @@
+// Testacular configuration
+
+var fs = require('fs');
+
+// Load from basic testacular configuration
+eval(fs.readFileSync('testacular.conf.js')+'');
+
+// list of files / patterns to load in the browser
+files = [
+  ANGULAR_SCENARIO,
+  ANGULAR_SCENARIO_ADAPTER,
+  'test/e2e/**/*.js'
+];
+
+// Proxy the root path to the location of app server
+proxies = {
+  '/': 'http://localhost:9000/'
+};


### PR DESCRIPTION
Angular end to end tests don't work by default
if this isn't added to the config
