### PR TITLE
Add support for generating Travis CI configs

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var yeoman = require('yeoman-generator');
@@ -29,4 +30,48 @@ util.inherits(KarmaGenerator, yeoman.generators.Base);
 KarmaGenerator.prototype.setupEnv = function setupEnv() {
   this.copy('karma.conf.js', 'karma.conf.js');
   this.copy('karma-e2e.conf.js', 'karma-e2e.conf.js');
+};
+
+KarmaGenerator.prototype.setupTravis = function setupTravis() {
+  if (!this.options.travis) {
+    return;
+  }
+
+  var done = this.async();
+  var cwd = this.options.cwd || process.cwd();
+  var packageJson = path.join(cwd, 'package.json');
+
+  this.copy('travis.yml', '.travis.yml');
+
+  // Rewrite the package.json to include a test script unless it's already
+  // specified.
+  fs.readFile(packageJson, { encoding: 'utf-8' }, function (err, content) {
+    var data;
+    if (err) {
+      this.log.error('Could not open package.json for reading.', err);
+      done();
+      return;
+    }
+
+    try {
+      data = JSON.parse(content);
+    } catch (err) {
+      this.log.error('Could not parse package.json.', err);
+      done();
+      return;
+    }
+
+    if (data.scripts && data.scripts.test) {
+      this.log.writeln('Test script already present in package.json. ' +
+                       'Skipping rewriting.');
+      done();
+      return;
+    }
+
+    data.scripts = data.scripts || {};
+    data.scripts.test = 'grunt test';
+
+
+    fs.writeFile(packageJson, JSON.stringify(data, null, 2), done);
+  }.bind(this));
 };

--- a/lib/templates/travis.yml
+++ b/lib/templates/travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - '0.8'
+  - '0.10'
+before_script:
+  - 'npm install -g bower grunt-cli'
+  - 'bower install'

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ Note that you'll need to install the `grunt-karma` plugin for Grunt and update y
 * `--coffee`
 
   Enable support for tests written in CoffeeScript.
+
+* `--travis`
+
+  Enable [Travis CI](https://travis-ci.org/) config generation.
   
   
 ## Configuration

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,13 @@
 
 var path = require('path');
 var helpers = require('yeoman-generator').test;
+var assert = require('assert');
+var fs = require('fs');
 
 describe('Karma generator test', function () {
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+    this.testDir = path.join(__dirname, 'temp');
+    helpers.testDirectory(this.testDir, function (err) {
       if (err) {
         return done(err);
       }
@@ -24,10 +27,76 @@ describe('Karma generator test', function () {
       'karma-e2e.conf.js'
     ];
 
+    this.app.options.travis = false;
     this.app.options['skip-install'] = true;
     this.app.run({}, function () {
       helpers.assertFiles(expected);
       done();
+    });
+  });
+
+  it('creates a .travis.yml if requested', function (done) {
+    var expected = [
+      '.travis.yml'
+    ];
+
+    this.app.options.travis = true;
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFiles(expected);
+      done();
+    });
+  });
+
+  describe('travis support', function () {
+    beforeEach(function () {
+      this.packageJson = path.join(this.testDir, 'package.json');
+    });
+
+    it('rewrites the test script in package.json if requested', function (done) {
+      console.log("JSON: ", this.packageJson);
+      fs.writeFileSync(this.packageJson, JSON.stringify({
+        name: 'test-package',
+        version: '0.0.0'
+      }));
+
+      this.app.options.travis = true;
+      this.app.options['skip-install'] = true;
+      this.app.run({}, function () {
+        fs.readFile(this.packageJson, function (err, content) {
+          if (err) {
+            throw err;
+          }
+
+          var data = JSON.parse(content);
+          assert(data && data.scripts && !!data.scripts.test);
+          done();
+        });
+      }.bind(this));
+    });
+
+    it('does not rewrite the test script if already present', function (done) {
+      fs.writeFileSync(this.packageJson, JSON.stringify({
+        name: 'test-package',
+        version: '0.0.0',
+        scripts: {
+          test: 'mocha'
+        }
+      }));
+
+      this.app.options.travis = true;
+      this.app.options['skip-install'] = true;
+      this.app.run({}, function () {
+        fs.readFile(this.packageJson, function (err, content) {
+          if (err) {
+            throw err;
+          }
+
+          var data = JSON.parse(content);
+          assert(data.scripts.test === 'mocha');
+          done();
+        });
+      }.bind(this));
     });
   });
 });


### PR DESCRIPTION
Fixes #28

This adds very basic support for Travis CI if you run the generator with `--travis` or pass `travis` as option at `hookFor`. All it really does is it adds a `travis.yml` file and adds a `test` script to the package.json which calls `grunt test`.
