### PR TITLE
generator-angular-633 - add missing dependencies to fix grunt test execu...

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -23,11 +23,19 @@ var KarmaGenerator = module.exports = function KarmaGenerator(args, options) {
   }
 
   this.on('end', function () {
-    if (!options['skip-install']) {
-      this.npmInstall(['grunt-karma', 'karma-ng-html2js-preprocessor', 'karma-ng-scenario'], {
-        saveDev: true
-      });
+    if (options['skip-install']) {
+      return;
     }
+
+    var packagesToBeInstalled = ['grunt-karma', 'karma-ng-html2js-preprocessor', 'karma-ng-scenario', 'karma-phantomjs-launcher']
+
+    if(this.testFramework === 'jasmine') {
+      packagesToBeInstalled.push('karma-jasmine');
+    }
+
+    this.npmInstall(packagesToBeInstalled, {
+      saveDev: true
+    });
   });
 };
 


### PR DESCRIPTION
According to https://github.com/yeoman/generator-angular/issues/633 - adding additional dependencies solve problem with `grunt test` execution after new project was generated by generator-angular.
