### PR TITLE
replaced --test-framework with --frameworks option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -34,12 +34,15 @@ module.exports = yeoman.generators.Base.extend({
       defaults: 8080
     });
 
-    this.option('test-framework', {
+    this.option('frameworks', {
       type: String,
-      desc: 'Specifies which testing framework to use',
+      desc: 'Specifies which testing frameworks to use (comma separated)',
       defaults: 'jasmine'
     });
-    this.options['test-framework'] = this.options['test-framework'].toLowerCase();
+    this.options.frameworks = notEmpty(this.options.frameworks);
+    this.frameworks = this.options.frameworks.map(function (framework) {
+      return framework.toLowerCase();
+    });
 
     this.option('browsers', {
       type: String,
@@ -115,10 +118,10 @@ module.exports = yeoman.generators.Base.extend({
       }.bind(this));
     }
 
-    // Add test-framework to the plugins list
-    if (this.options['test-framework']) {
-      this.options.plugins.push('karma-' + this.options['test-framework']);
-    }
+    // Add frameworks to the plugins list
+    this.options.plugins = this.options.plugins.concat(this.frameworks.map(function(framework) {
+      return 'karma-' + framework;
+    }));
 
     if (this.options.coffee) {
       this.options.plugins.push('karma-coffee-preprocessor');

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ There are a lot of options going on here. None of them are required and most are
 
 Options are specified after `yo karma`. Example:
 
-`yo karma --skip-install --test-framework=jasmine --app-files='app/**/*.js,public/**/*.js'`
+`yo karma --skip-install --frameworks=jasmine --app-files='app/**/*.js,public/**/*.js'`
 
 The full list:
 
@@ -37,9 +37,9 @@ The full list:
 
   Use CoffeeScript instead of JavaScript.
 
- * `--test-framework` Type: String, Default: 'jasmine'
+ * `--frameworks` Type: String, Default: 'jasmine'
 
-  Specifies which testing framework to use.
+  Specifies which testing frameworks to use (CSV list). Example `--frameworks=mocha,chai,requirejs,sinon`
 
  * `--browsers` Type: String, Default: 'PhantomJS'
 

--- a/templates/karma.conf.coffee
+++ b/templates/karma.conf.coffee
@@ -9,7 +9,8 @@ module.exports = (config) ->
     basePath: '<%= options["base-path"] %>'
 
     # testing framework to use (jasmine/mocha/qunit/...)
-    frameworks: ['<%= options["test-framework"] %>']
+    # as well as any additional frameworks (requirejs/chai/sinon/...)
+    frameworks: [<%= templateArray(frameworks) %>]
 
     # list of files / patterns to load in the browser
     files: [<%= templateArray(configFiles, options["files-comments"], true) %>],

--- a/templates/karma.conf.js
+++ b/templates/karma.conf.js
@@ -14,7 +14,8 @@ module.exports = function(config) {
     basePath: '<%= options["base-path"] %>',
 
     // testing framework to use (jasmine/mocha/qunit/...)
-    frameworks: ['<%= options["test-framework"] %>'],
+    // as well as any additional frameworks (requirejs/chai/sinon/...)
+    frameworks: [<%= templateArray(frameworks) %>],
 
     // list of files / patterns to load in the browser
     files: [<%= templateArray(configFiles, options["files-comments"]) %>],

--- a/test/config.mock.json
+++ b/test/config.mock.json
@@ -1,6 +1,6 @@
 {
   "base-path": "<%= options['base-path'] %>",
-  "frameworks": ["<%= options['test-framework'] %>"],
+  "frameworks": <%= JSON.stringify(frameworks) %>,
   "files": <%= JSON.stringify(configFiles) %>,
   "exclude": <%= JSON.stringify(options['exclude-files']) %>,
   "port": <%= options['web-port'] %>,

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -10,7 +10,7 @@ describe('Karma generator options test', function () {
     var config = {
       'base-path': 'new base-path',
       'web-port': 80,
-      'test-framework': 'mocha',
+      'frameworks': 'mocha,chai,sinon',
       'browsers': 'Chrome,PhantomJS,Firefox',
       'app-files': 'public/**/*.js,apps/*.js',
       'files-comments': 'bower:js,endbower',
@@ -33,8 +33,9 @@ describe('Karma generator options test', function () {
           config['config-path'],
           config['config-file']
         ));
+        var frameworks = config.frameworks.split(',');
         assert.equal(config['base-path'], test['base-path']);
-        assert.equal(config['test-framework'], test.frameworks);
+        assert.deepEqual(frameworks, test.frameworks);
         assert.equal(config['web-port'], test.port);
         assert.deepEqual(config.browsers.split(','), test.browsers);
         assert.deepEqual(config['exclude-files'].split(','), test.exclude);
@@ -44,7 +45,9 @@ describe('Karma generator options test', function () {
             config.browsers.split(',').map(function(browser) {
               return 'karma-' + browser.toLowerCase() + '-launcher';
             }),
-            'karma-' + config['test-framework']
+            frameworks.map(function(framework) {
+              return 'karma-' + framework.toLowerCase();
+            })
           ),
           test.plugins
         );


### PR DESCRIPTION
- accepts new option to pass comma seperated list of additional frameworks that
karma should load (i.e. requirejs, chai, sinon, etc).
- those framworks are concatenated with the test-framework and added to the karma
configuration file (both .js and .coffee versions).
- those frameworks are added to the list of plugins (prefixed w/
karma-) and optionally installed via npm.
- modified test to run with this option.
- updated readme to doc new option
- bumped version to 0.10.0

resolves #72