### PR TITLE
Upgrade yeoman-generator to version 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "underscore": "^1.6.0",
-    "yeoman-generator": "^0.17.1",
+    "yeoman-generator": "^0.19.1",
     "sorted-object": "~1.0.0"
   },
   "devDependencies": {

--- a/templates/karma.conf.coffee
+++ b/templates/karma.conf.coffee
@@ -6,20 +6,20 @@
 module.exports = (config) ->
   config.set
     # base path, that will be used to resolve files and exclude
-    basePath: '<%= options["base-path"] %>'
+    basePath: '<%= basePath %>'
 
     # testing framework to use (jasmine/mocha/qunit/...)
     # as well as any additional frameworks (requirejs/chai/sinon/...)
     frameworks: [<%= templateArray(frameworks) %>]
 
     # list of files / patterns to load in the browser
-    files: [<%= templateArray(configFiles, options["files-comments"], true) %>],
+    files: [<%= templateArray(configFiles, fileComments, true) %>],
 
     # list of files / patterns to exclude
-    exclude: [<%= templateArray(options["exclude-files"], true) %>]
+    exclude: [<%= templateArray(exclude, true) %>]
 
     # web server port
-    port: <%= options['web-port'] %>
+    port: <%= port %>
 
     # level of logging
     # possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
@@ -33,10 +33,10 @@ module.exports = (config) ->
     # - Safari (only Mac)
     # - PhantomJS
     # - IE (only Windows)
-    browsers: [<%= templateArray(options.browsers, true) %>]
+    browsers: [<%= templateArray(browsers, true) %>]
 
     # Which plugins to enable
-    plugins: [<%= templateArray(options.plugins, true) %>]
+    plugins: [<%= templateArray(plugins, true) %>]
 
     # enable / disable watching file and executing tests whenever any file changes
     autoWatch: true

--- a/templates/karma.conf.js
+++ b/templates/karma.conf.js
@@ -11,20 +11,20 @@ module.exports = function(config) {
     autoWatch: true,
 
     // base path, that will be used to resolve files and exclude
-    basePath: '<%= options["base-path"] %>',
+    basePath: '<%= basePath %>',
 
     // testing framework to use (jasmine/mocha/qunit/...)
     // as well as any additional frameworks (requirejs/chai/sinon/...)
     frameworks: [<%= templateArray(frameworks) %>],
 
     // list of files / patterns to load in the browser
-    files: [<%= templateArray(configFiles, options["files-comments"]) %>],
+    files: [<%= templateArray(configFiles, fileComments) %>],
 
     // list of files / patterns to exclude
-    exclude: [<%= templateArray(options["exclude-files"]) %>],
+    exclude: [<%= templateArray(exclude) %>],
 
     // web server port
-    port: <%= options['web-port'] %>,
+    port: <%= port %>,
 
     // Start these browsers, currently available:
     // - Chrome
@@ -34,10 +34,10 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: [<%= templateArray(options.browsers) %>],
+    browsers: [<%= templateArray(browsers) %>],
 
     // Which plugins to enable
-    plugins: [<%= templateArray(options.plugins) %>],
+    plugins: [<%= templateArray(plugins) %>],
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/test/config.mock.json
+++ b/test/config.mock.json
@@ -1,9 +1,9 @@
 {
-  "base-path": "<%= options['base-path'] %>",
+  "base-path": "<%= basePath %>",
   "frameworks": <%= JSON.stringify(frameworks) %>,
   "files": <%= JSON.stringify(configFiles) %>,
-  "exclude": <%= JSON.stringify(options['exclude-files']) %>,
-  "port": <%= options['web-port'] %>,
-  "browsers": <%= JSON.stringify(options.browsers) %>,
-  "plugins": <%= JSON.stringify(options.plugins) %>
+  "exclude": <%= JSON.stringify(exclude) %>,
+  "port": <%= port %>,
+  "browsers": <%= JSON.stringify(browsers) %>,
+  "plugins": <%= JSON.stringify(plugins) %>
 }

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -1,4 +1,4 @@
-/*global describe, beforeEach, afterEach, it */
+/*global describe, beforeEach, it */
 'use strict';
 
 var assert = require('yeoman-generator').assert;
@@ -8,98 +8,106 @@ var join = require('path').join;
 describe('Karma generator creation test', function () {
   describe('creates expected files', function () {
     var gen;
-    beforeEach(function(done) {
-      gen = helpers.run(join(__dirname, '../app'))
-        .inDir(join(__dirname, 'temp'));
-      done();
+    beforeEach(function (done) {
+      gen = helpers.run(join(__dirname, '../app'));
+      gen.inTmpDir(function (dir) {
+        done();
+      });
     });
 
-    it('creates expected JS file in default folder', function(done) {
+    it('creates expected JS file in default folder', function (done) {
       gen.on('end', function () {
         assert.file(['test/karma.conf.js']);
         done();
       });
     });
 
-    it('creates expected JS file in specified folder', function(done) {
+    it('creates expected JS file in specified folder', function (done) {
       gen.withOptions({'config-path': 'testingFolder'}).on('end', function () {
         assert.file(['testingFolder/karma.conf.js']);
         done();
       });
     });
 
-    it('creates expected CS file in default folder', function(done) {
+    it('creates expected CS file in default folder', function (done) {
       gen.withOptions({coffee: true}).on('end', function () {
         assert.file(['test/karma.conf.coffee']);
         done();
       });
     });
 
-    it('creates expected CS file in specified folder', function(done) {
+    it('creates expected CS file in specified folder', function (done) {
       gen.withOptions({'config-path': 'csFolder', coffee: true}).on('end', function () {
         assert.file(['csFolder/karma.conf.coffee']);
         done();
       });
     });
 
-    it('creates a Gruntfile', function(done) {
+    it('creates a Gruntfile', function (done) {
       gen.withOptions({'gruntfile-path': '.'}).on('end', function () {
         assert.file(['test/karma.conf.js', 'Gruntfile.js']);
         done();
       });
     });
+  });
 
-    describe('stdout ward', function () {
-      var logMessage;
-      var stderrWriteBackup = process.stderr.write;
+  describe('stdout ward', function () {
+    var gen;
+    var logMessage = '';
 
-      beforeEach(function () {
-        logMessage = '';
-        process.stderr.write = (function () {
-          return function (str) {
-            logMessage += str;
+    beforeEach(function (done) {
+      logMessage = '';
+      gen = helpers.run(join(__dirname, '../app'))
+        .on('ready', function () {
+          gen.generator.log.__olderror = gen.generator.log.error;
+          gen.generator.log.error = function (){
+            logMessage += arguments[0];
+            gen.generator.log.__olderror.apply(gen.generator.log, arguments);
           };
-        }(process.stderr.write));
-      });
+        })
+        .inTmpDir(function () {
+          done();
+        });
+    });
 
-      afterEach(function () {
-        process.stderr.write = stderrWriteBackup;
-      });
-
-      it('creates a travis file but warns about missing package.json', function(done) {
-        gen.withOptions({travis: true}).on('end', function () {
+    it('creates a travis file but warns about missing package.json', function (done) {
+      gen.withOptions({travis: true})
+        .on('end', function () {
+          gen.generator.log.error = gen.generator.log.__olderror;
           assert.file(['.travis.yml']);
           assert(
             logMessage.indexOf('Could not open package.json for reading.') > -1
           );
           done();
         });
-      });
-
     });
   });
 
-  it('creates a travis file and updates package.json', function(done) {
-    helpers.testDirectory(join('test', 'temp'), function () {
-      var gen = helpers.run(join(__dirname, '../app'));
-      require('fs').writeFileSync('package.json', '{}');
-      gen.withOptions({travis: true}).on('end', function () {
+  it('creates a travis file and updates package.json', function (done) {
+    helpers
+      .run(join(__dirname, '../app'))
+      .withOptions({travis: true, force: true})
+      .inTmpDir(function (dir){
+        require('fs').writeFileSync(join(dir,'package.json'), '{}');
+      })
+      .on('end', function () {
         assert.file(['.travis.yml']);
         assert.fileContent('package.json', /grunt test/);
         done();
       });
-    });
   });
 
-  it('updates package.json with karma dependencies', function(done) {
-    helpers.testDirectory(join('test', 'temp'), function () {
-      var gen = helpers.run(join(__dirname, '../app'));
-      require('fs').writeFileSync('package.json', '{"dependencies":{"grunt":"1.0.0"}}');
-      gen.withOptions({travis: true}).on('end', function () {
+  it('updates package.json with karma dependencies', function (done) {
+    helpers
+      .run(join(__dirname, '../app'))
+      .withOptions({travis: true, force: true})
+      .inTmpDir(function (dir){
+        require('fs').writeFileSync(join(dir,'package.json'), '{"dependencies":{"grunt":"1.0.0"}}');
+      })
+      .on('end', function () {
         assert.fileContent('package.json', /karma/);
         assert.fileContent('package.json', /grunt/);
         done();
       });
-    });
   });
 });


### PR DESCRIPTION
I've tried to upgrade the generator to the 0.19.1 API as it was using fs directly.

Let me know if there's something wrong.

BTW, I tried to use sinom to spy on the generator.log.error method for testing asserts but it seems to be already wrapped.